### PR TITLE
Fix makefile, add libs_only option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,17 @@
-# Project files
+# VS Project files
 *.vs/
 CMakeSettings.json
 *.dep.inc
 *.mk
+
+# CMake
+cmake_install.cmake
+CMakeFiles/
+CMakeCache.txt
+Makefile
+
+# custom clean script
+clean_build
 
 # Prerequisites
 *.d

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(i8080emu)
-set(EXE_NAME i8080emu)
+set(EXE_NAME i8080-emu)
 
 option(FIRST_TIME_SETUP "Force installation of dependencies if not available, and pull test files with git lfs." OFF)
+option(LIBS_ONLY "Compile the libi8080emu and libi8080 libraries only." OFF)
 
 # Search for dependencies and auto-install them if possible
 if (FIRST_TIME_SETUP)
@@ -82,17 +83,18 @@ endif()
 include_directories(libi8080emu/libi8080/include)
 add_library(i8080 STATIC libi8080emu/libi8080/src/i8080.c libi8080emu/libi8080/src/i8080_sync.c)
 include_directories(libi8080emu/include)
-add_library(i8080-wrapper STATIC libi8080emu/src/emu.c libi8080emu/src/emu_debug.c)
+add_library(i8080emu STATIC libi8080emu/src/emu.c libi8080emu/src/emu_debug.c)
 # link libi8080emu to libi8080
-target_link_libraries(i8080-wrapper PUBLIC i8080)
+target_link_libraries(i8080emu PUBLIC i8080)
 
 # copy test files to the build folder
 file(COPY libi8080emu/tests DESTINATION ${CMAKE_BINARY_DIR})
 
-# Generate build system
-add_executable(${EXE_NAME} main.cpp run_tests.cpp)
-target_link_libraries(${EXE_NAME} i8080-wrapper)
-target_link_libraries(${EXE_NAME} Threads::Threads)
-target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:DEBUG>:${i8080_DEBUG_FLAGS}>")
-target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:RELEASE>:${i8080_RELEASE_FLAGS}>")
-
+if (NOT LIBS_ONLY)
+    # Generate build system
+    add_executable(${EXE_NAME} main.cpp run_tests.cpp)
+    target_link_libraries(${EXE_NAME} i8080emu)
+    target_link_libraries(${EXE_NAME} Threads::Threads)
+    target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:DEBUG>:${i8080_DEBUG_FLAGS}>")
+    target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:RELEASE>:${i8080_RELEASE_FLAGS}>")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ set(CMAKE_C_STANDARD 90)
 set(CMAKE_CXX_STANDARD 11)
 
 if (MSVC)
-    set(i8080_DEBUG_FLAGS /W4 /WX /DEBUG:FASTLINK /Od /EHa)
+    set(i8080_DEBUG_FLAGS /W4 /WX /DEBUG /Od /EHa)
     set(i8080_RELEASE_FLAGS /W4 /WX /O2 /EHsc)
 else()
     set(i8080_DEBUG_FLAGS -g -O0 -Wall -Wextra -Werror)
@@ -84,6 +84,11 @@ include_directories(libi8080emu/libi8080/include)
 add_library(i8080 STATIC libi8080emu/libi8080/src/i8080.c libi8080emu/libi8080/src/i8080_sync.c)
 include_directories(libi8080emu/include)
 add_library(i8080emu STATIC libi8080emu/src/emu.c libi8080emu/src/emu_debug.c)
+# compile both libraries
+target_compile_options(i8080 PUBLIC "$<$<CONFIG:DEBUG>:${i8080_DEBUG_FLAGS}>"
+                                    "$<$<CONFIG:RELEASE>:${i8080_RELEASE_FLAGS}>")
+target_compile_options(i8080emu PUBLIC "$<$<CONFIG:DEBUG>:${i8080_DEBUG_FLAGS}>"
+                                       "$<$<CONFIG:RELEASE>:${i8080_RELEASE_FLAGS}>")
 # link libi8080emu to libi8080
 target_link_libraries(i8080emu PUBLIC i8080)
 
@@ -95,6 +100,6 @@ if (NOT LIBS_ONLY)
     add_executable(${EXE_NAME} main.cpp run_tests.cpp)
     target_link_libraries(${EXE_NAME} i8080emu)
     target_link_libraries(${EXE_NAME} Threads::Threads)
-    target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:DEBUG>:${i8080_DEBUG_FLAGS}>")
-    target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:RELEASE>:${i8080_RELEASE_FLAGS}>")
+    target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:DEBUG>:${i8080_DEBUG_FLAGS}>"
+                                              "$<$<CONFIG:RELEASE>:${i8080_RELEASE_FLAGS}>")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,13 @@ cmake_minimum_required(VERSION 3.1.0)
 project(i8080emu)
 set(EXE_NAME i8080emu)
 
-option(FORCE_INSTALL_DEP "Force installation of dependencies if not available." OFF)
+option(FIRST_TIME_SETUP "Force installation of dependencies if not available, and pull test files with git lfs." OFF)
 
 # Search for dependencies and auto-install them if possible
-if (FORCE_INSTALL_DEP)
+if (FIRST_TIME_SETUP)
+
+    set(GIT_LFS_INSTALL_AND_PULL cd ${CMAKE_SOURCE_DIR} && git lfs install && git lfs pull)
+
     if (WIN32)
         message(STATUS "Installing dependencies Chocolatey and git-lfs if not available...")
         execute_process(
@@ -31,17 +34,16 @@ if (FORCE_INSTALL_DEP)
     else()
         message(STATUS "Installation/verification of dependencies complete.")
     endif()
-endif(FORCE_INSTALL_DEP)
 
-# Get test files from git lfs
-set(GIT_LFS_INSTALL_AND_PULL cd ${CMAKE_SOURCE_DIR} && git lfs install && git lfs pull)
-message(STATUS "Initializing git-lfs and pulling test files...")
-execute_process(COMMAND ${GIT_LFS_INSTALL_AND_PULL} RESULT_VARIABLE GIT_LFS_SUCCESS)
-if (NOT GIT_LFS_SUCCESS)
-    message(FATAL_ERROR "Unable to pull test files. Download the files manually to libi8080emu/tests. Abort.")
-else()
-    message(STATUS "libi8080emu test files pulled successfully.")
-endif()
+    # Get test files from git lfs
+    message(STATUS "Initializing git-lfs and pulling test files...")
+    execute_process(COMMAND ${GIT_LFS_INSTALL_AND_PULL} RESULT_VARIABLE GIT_LFS_SUCCESS)
+    if (NOT GIT_LFS_SUCCESS)
+        message(FATAL_ERROR "Unable to pull test files. Download the files manually to libi8080emu/tests. Abort.")
+    else()
+        message(STATUS "libi8080emu test files pulled successfully.")
+    endif()
+endif(FIRST_TIME_SETUP)
 
 # Find system threads library
 find_package(Threads REQUIRED)
@@ -67,6 +69,9 @@ add_library(i8080-wrapper STATIC libi8080emu/src/emu.c libi8080emu/src/emu_debug
 # link libi8080emu to libi8080
 target_link_libraries(i8080-wrapper PUBLIC i8080)
 
+# copy test files to the build folder
+file(COPY libi8080emu/tests DESTINATION ${CMAKE_BINARY_DIR})
+
 # Generate build system
 add_executable(${EXE_NAME} main.cpp run_tests.cpp)
 target_link_libraries(${EXE_NAME} i8080-wrapper)
@@ -75,5 +80,3 @@ target_link_libraries(${EXE_NAME} Threads::Threads)
 target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:DEBUG>:${i8080_DEBUG_FLAGS}>")
 target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:RELEASE>:${i8080_RELEASE_FLAGS}>")
 
-# copy test files to the build folder
-file(COPY libi8080emu/tests DESTINATION ${CMAKE_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,40 +8,61 @@ option(FIRST_TIME_SETUP "Force installation of dependencies if not available, an
 if (FIRST_TIME_SETUP)
 
     set(GIT_LFS_INSTALL_AND_PULL cd ${CMAKE_SOURCE_DIR} && git lfs install && git lfs pull)
+    set(WIN_CHOCO_GIT_LFS_INSTALL runas powershell.exe -command "choco install -y git-lfs; refreshenv")
 
     if (WIN32)
         message(STATUS "Installing dependencies Chocolatey and git-lfs if not available...")
-        execute_process(
-            COMMAND runas powershell.exe -ExecutionPolicy Bypass -NoProfile
-                               -command "iwr https://chocolatey.org/install.ps1 -UseBasicParsing | iex"
-        )
-        execute_process(COMMAND runas powershell.exe -command "choco install git-lfs" RESULT_VARIABLE DEP_SUCCESS)
+        execute_process(COMMAND runas powershell.exe
+                                -command "Get-PackageProvider "Chocolatey"
+                        RESULT_VARIABLE CHOCO_AVAILABLE)
+        if (NOT CHOCO_AVAILABLE)
+            # If chocolatey is not available, install it and git-lfs
+            execute_process(COMMAND runas powershell.exe -ExecutionPolicy Bypass -NoProfile
+                                    -command "iwr https://chocolatey.org/install.ps1 -UseBasicParsing | iex"
+                            RESULT_VARIABLE DEP_SUCCESS)
+            if (DEP_SUCCESS)
+                execute_process(COMMAND ${WIN_CHOCO_GIT_LFS_INSTALL}
+                                RESULT_VARIABLE DEP_SUCCESS)
+            endif()
+        else()
+            # Check if git-lfs is already installed through choco
+            execute_process(COMMAND runas -powershell.exe
+                                    -command "choco list -lo | Select-String -Pattern '^git-lfs*'"
+                            RESULT_VARIABLE DEP_SUCCESS)
+            if (NOT DEP_SUCCESS)
+                execute_process(COMMAND ${WIN_CHOCO_GIT_LFS_INSTALL}
+                                RESULT_VARIABLE DEP_SUCCESS)
+            endif()
+        endif()
+
     elseif (UNIX)
         message(STATUS "Installing dependency git-lfs if not available...")
         # Search for packages beginning with git-lfs
-        execute_process(COMMAND sudo apt-cache search --names-only "^git-lfs.*" OUTPUT_VARIABLE GIT_LFS_APT_SEARCH)
+        execute_process(COMMAND sudo apt-cache search --names-only "^git-lfs.*"
+                        OUTPUT_VARIABLE GIT_LFS_APT_SEARCH)
         # If not found, attempt to install
         if (GIT_LFS_APT_SEARCH MATCHES "^$")
-            execute_process(COMMAND sudo apt-get --yes install git-lfs RESULT_VARIABLE DEP_SUCCESS)
+            execute_process(COMMAND sudo apt-get --yes install git-lfs
+                            RESULT_VARIABLE DEP_SUCCESS)
         else()
             set(DEP_SUCCESS 1)
         endif()
     else()
         message(FATAL_ERROR "Unrecognized build environment. Install dependencies yourself before running cmake.")
     endif()
-    if (NOT DEP_SUCCESS)
-        message(SEND_ERROR "Installation of dependencies failed.")
-    else()
-        message(STATUS "Installation/verification of dependencies complete.")
-    endif()
 
     # Get test files from git lfs
-    message(STATUS "Initializing git-lfs and pulling test files...")
-    execute_process(COMMAND ${GIT_LFS_INSTALL_AND_PULL} RESULT_VARIABLE GIT_LFS_SUCCESS)
-    if (NOT GIT_LFS_SUCCESS)
-        message(FATAL_ERROR "Unable to pull test files. Download the files manually to libi8080emu/tests. Abort.")
+    if (DEP_SUCCESS)
+        message(STATUS "Initializing git-lfs and pulling test files...")
+        execute_process(COMMAND ${GIT_LFS_INSTALL_AND_PULL}
+                        RESULT_VARIABLE GIT_LFS_SUCCESS)
+        if (NOT GIT_LFS_SUCCESS)
+            message(FATAL_ERROR "Unable to pull test files. Download the files manually to libi8080emu/tests. Abort.")
+        else()
+            message(STATUS "libi8080emu test files pulled successfully.")
+        endif()
     else()
-        message(STATUS "libi8080emu test files pulled successfully.")
+        message(SEND_ERROR "Installation of dependencies failed.")
     endif()
 endif(FIRST_TIME_SETUP)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,59 +7,55 @@ option(FIRST_TIME_SETUP "Force installation of dependencies if not available, an
 # Search for dependencies and auto-install them if possible
 if (FIRST_TIME_SETUP)
 
-    set(GIT_LFS_INSTALL_AND_PULL cd ${CMAKE_SOURCE_DIR} && git lfs install && git lfs pull)
-    set(WIN_CHOCO_GIT_LFS_INSTALL runas powershell.exe -command "choco install -y git-lfs; refreshenv")
+    set(CHECK_IF_GIT_LFS_EXISTS git-lfs --version)
+    execute_process(COMMAND ${CHECK_IF_GIT_LFS_EXISTS}
+                        RESULT_VARIABLE DEP_SUCCESS)
 
-    if (WIN32)
-        message(STATUS "Installing dependencies Chocolatey and git-lfs if not available...")
-        execute_process(COMMAND runas powershell.exe
-                                -command "Get-PackageProvider "Chocolatey"
-                        RESULT_VARIABLE CHOCO_AVAILABLE)
-        if (NOT CHOCO_AVAILABLE)
-            # If chocolatey is not available, install it and git-lfs
-            execute_process(COMMAND runas powershell.exe -ExecutionPolicy Bypass -NoProfile
-                                    -command "iwr https://chocolatey.org/install.ps1 -UseBasicParsing | iex"
-                            RESULT_VARIABLE DEP_SUCCESS)
-            if (DEP_SUCCESS)
+    # attempt to install if not available
+    if (NOT DEP_SUCCESS)
+        set(WIN_CHECK_IF_CHOCO_EXISTS choco --version)
+        set(WIN_CHOCO_INSTALL runas powershell.exe -ExecutionPolicy Bypass -NoProfile
+                                        -command "iwr https://chocolatey.org/install.ps1 -UseBasicParsing | iex")
+        set(WIN_CHOCO_GIT_LFS_INSTALL runas powershell.exe -command "choco install -y git-lfs; refreshenv")
+        set(UNIX_GIT_LFS_INSTALL sudo apt-get --yes git-lfs)
+        set(GIT_LFS_INIT_AND_PULL cd ${CMAKE_SOURCE_DIR} && git lfs install && git lfs pull)
+
+        if (WIN32)
+            message(STATUS "Installing dependencies Chocolatey and git-lfs if not available...")
+            execute_process(COMMAND ${WIN_CHECK_IF_CHOCO_EXISTS}
+                            RESULT_VARIABLE CHOCO_AVAILABLE)
+            if (NOT CHOCO_AVAILABLE)
+                # If chocolatey is not available, install it and git-lfs
+                execute_process(COMMAND ${WIN_CHOCO_INSTALL}
+                                RESULT_VARIABLE DEP_SUCCESS)
+                if (DEP_SUCCESS)
+                    execute_process(COMMAND ${WIN_CHOCO_GIT_LFS_INSTALL}
+                                    RESULT_VARIABLE DEP_SUCCESS)
+                endif()
+            else()
+                # install through choco
                 execute_process(COMMAND ${WIN_CHOCO_GIT_LFS_INSTALL}
                                 RESULT_VARIABLE DEP_SUCCESS)
             endif()
-        else()
-            # Check if git-lfs is already installed through choco
-            execute_process(COMMAND runas -powershell.exe
-                                    -command "choco list -lo | Select-String -Pattern '^git-lfs*'"
-                            RESULT_VARIABLE DEP_SUCCESS)
-            if (NOT DEP_SUCCESS)
-                execute_process(COMMAND ${WIN_CHOCO_GIT_LFS_INSTALL}
-                                RESULT_VARIABLE DEP_SUCCESS)
-            endif()
-        endif()
 
-    elseif (UNIX)
-        message(STATUS "Installing dependency git-lfs if not available...")
-        # Search for packages beginning with git-lfs
-        execute_process(COMMAND sudo apt-cache search --names-only "^git-lfs.*"
-                        OUTPUT_VARIABLE GIT_LFS_APT_SEARCH)
-        # If not found, attempt to install
-        if (GIT_LFS_APT_SEARCH MATCHES "^$")
-            execute_process(COMMAND sudo apt-get --yes install git-lfs
-                            RESULT_VARIABLE DEP_SUCCESS)
+        elseif (UNIX)
+            message(STATUS "Installing dependency git-lfs if not available...")
+                execute_process(COMMAND ${UNIX_GIT_LFS_INSTALL}
+                                RESULT_VARIABLE DEP_SUCCESS)
         else()
-            set(DEP_SUCCESS 1)
+            message(FATAL_ERROR "Unrecognized build environment. Install dependencies yourself before running cmake.")
         endif()
-    else()
-        message(FATAL_ERROR "Unrecognized build environment. Install dependencies yourself before running cmake.")
     endif()
 
     # Get test files from git lfs
     if (DEP_SUCCESS)
         message(STATUS "Initializing git-lfs and pulling test files...")
-        execute_process(COMMAND ${GIT_LFS_INSTALL_AND_PULL}
+        execute_process(COMMAND ${GIT_LFS_INIT_AND_PULL}
                         RESULT_VARIABLE GIT_LFS_SUCCESS)
-        if (NOT GIT_LFS_SUCCESS)
-            message(FATAL_ERROR "Unable to pull test files. Download the files manually to libi8080emu/tests. Abort.")
-        else()
+        if (GIT_LFS_SUCCESS)
             message(STATUS "libi8080emu test files pulled successfully.")
+        else()
+            message(FATAL_ERROR "Unable to pull test files. Download the files manually to libi8080emu/tests. Abort.")
         endif()
     else()
         message(SEND_ERROR "Installation of dependencies failed.")
@@ -97,7 +93,6 @@ file(COPY libi8080emu/tests DESTINATION ${CMAKE_BINARY_DIR})
 add_executable(${EXE_NAME} main.cpp run_tests.cpp)
 target_link_libraries(${EXE_NAME} i8080-wrapper)
 target_link_libraries(${EXE_NAME} Threads::Threads)
-# append to the debug and release flags
 target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:DEBUG>:${i8080_DEBUG_FLAGS}>")
 target_compile_options(${EXE_NAME} PUBLIC "$<$<CONFIG:RELEASE>:${i8080_RELEASE_FLAGS}>")
 

--- a/libi8080emu/libi8080/src/i8080.c
+++ b/libi8080emu/libi8080/src/i8080.c
@@ -242,21 +242,21 @@ static void i8080_mov_get_reg_pair(i8080 * const cpu, emu_word_t opcode, emu_wor
 
     switch (hi_opcode) {
         case 0x40:
-            if (lo_opcode >= 0x00 && lo_opcode <= 0x07) {
+            if (lo_opcode <= 0x07) {
                 *left = &cpu->b;
             } else if (lo_opcode >= 0x08 && lo_opcode <= 0x0f) {
                 *left = &cpu->c;
             }
             break;
         case 0x50:
-            if (lo_opcode >= 0x00 && lo_opcode <= 0x07) {
+            if (lo_opcode <= 0x07) {
                 *left = &cpu->d;
             } else if (lo_opcode >= 0x08 && lo_opcode <= 0x0f) {
                 *left = &cpu->e;
             }
             break;
         case 0x60:
-            if (lo_opcode >= 0x00 && lo_opcode <= 0x07) {
+            if (lo_opcode <= 0x07) {
                 *left = &cpu->h;
             } else if (lo_opcode >= 0x08 && lo_opcode <= 0x0f) {
                 *left = &cpu->l;

--- a/libi8080emu/src/emu.c
+++ b/libi8080emu/src/emu.c
@@ -135,7 +135,7 @@ static int i8080_cpm_zero_page(void * const udata) {
 
                 /* Process commands */
                 if (strncmp(input_buf, "RUN ", 4) == 0) {
-                    if (sscanf(&input_buf[4], ADDR_T_SCN_FORMAT, &run_addr) == 1 && run_addr >= 0 && run_addr <= 0xffff) {
+                    if (sscanf(&input_buf[4], ADDR_T_SCN_FORMAT, &run_addr) == 1) {
                         /* address is in correct format and within bounds */
                         #undef LEN_INPUT_BUF
                         goto command_run;


### PR DESCRIPTION
Compile libraries libi8080emu and libi8080 with debug and release flags too, and correct any warnings/errors generated by doing this.

Add LIBS_ONLY option to CMakeLists.txt, so only the c89-compliant libs can be built.